### PR TITLE
Fix for course about page in safari.

### DIFF
--- a/edx-platform/teclisboa/lms/static/sass/partials/lms/theme/_extras.scss
+++ b/edx-platform/teclisboa/lms/static/sass/partials/lms/theme/_extras.scss
@@ -443,3 +443,7 @@ div.u-field.u-field-social.u-field-auth-saml-ist {
 		opacity: 1;
 	}
 }
+
+.course-info .main-cta.safari-wrapper {
+  padding-bottom: 0px;
+}


### PR DESCRIPTION
This pr fix an error in the course about page only for safari.
To-do related: https://3.basecamp.com/3966315/buckets/8050706/todos/3382307252
